### PR TITLE
Access to new Linode's private IP address, etc

### DIFF
--- a/lib/chef/knife/linode_server_create.rb
+++ b/lib/chef/knife/linode_server_create.rb
@@ -234,12 +234,14 @@ class Chef
         bootstrap.config[:environment] = config[:environment]
         bootstrap.config[:host_key_verify] = config[:host_key_verify]
         bootstrap.config[:first_boot_attributes] = {
-          'linode_id' => server.id.to_s,
-          'datacenter_id' => locate_config_value(:linode_datacenter),
-          'linode_flavor_id' => locate_config_value(:linode_flavor),
-          'linode_image_id' => locate_config_value(:linode_image),
-          'linode_kernel_id' => locate_config_value(:linode_kernel),
-          'ip_addresses' => server.ips.map(&:ip)
+          'firstboot_linode' => {
+            'server_id' => server.id.to_s,
+            'datacenter_id' => locate_config_value(:linode_datacenter),
+            'flavor_id' => locate_config_value(:linode_flavor),
+            'image_id' => locate_config_value(:linode_image),
+            'kernel_id' => locate_config_value(:linode_kernel),
+            'ip_addresses' => server.ips.map(&:ip)
+          }
         }
         bootstrap
       end


### PR DESCRIPTION
I see that new Linodes are given a private IP address automatically, but I couldn't find a way to get to the private IP address from within the new Linode's initial chef-client run.

This commit changes linode_server_create to pass the IP addresses and other node info into the first_boot_attributes, then modified my bootstrap script to add the private interface to /etc/network/interface (which allows me to then use Linsides' apt-cacher-ng right away, which really sped up Linode provisioning). Here's our bootstrap that uses this: https://gist.github.com/3212198

Or is there a better way for this to work?
