### PR TITLE
[KNIFE-295] show details of a linode server

### DIFF
--- a/lib/chef/knife/linode_server_show.rb
+++ b/lib/chef/knife/linode_server_show.rb
@@ -30,9 +30,34 @@ class Chef
 
       def run
 
+        dc_location = {}
+        flavors = []
+        connection.data_centers.map { |dc| dc_location[dc.id] = dc.location }
+
+        connection.flavors.each do |flavor|
+          flavors << {:id => flavor.id, :name=> flavor.name, :ram => flavor.ram,
+            :disk=> flavor.disk, :price => flavor.price }
+        end
+
         validate!
         server = connection.servers.get(@name_args.first)
-        ui.output(server.attributes)
+        server_data = Hash.new
+        server_data[:attributes] = server.attributes
+        server_data[:linode_id] = server.id
+        server_data[:name] = server.name
+        server_data[:ips] = server.ips.map { |x| x.ip }.join(",")
+        server_data[:status] = server.status
+        server_data[:backups] = connection.linode_list(server.id).body['DATA'][0]['BACKUPSENABLED']
+        server_data[:datacenter_id] = connection.linode_list(server.id).body['DATA'][0]['DATACENTERID']
+        server_data[:datacenter_location] =dc_location[connection.linode_list(server.id).body['DATA'][0]['DATACENTERID']]
+        flavor =  flavors.select{|f| f[:ram] == server.attributes[:totalram] }
+        unless flavor.empty?
+          server_data[:flavor] = flavor.first
+        else
+          ui.warn("Cant detect the flavor of linode srevre (id:#{server.id})")
+          ui.warn("Total ram: #{server.attributes[:totalram]}")
+        end
+        ui.output(server_data)
       end
     end
   end


### PR DESCRIPTION
https://tickets.opscode.com/browse/KNIFE-295

adds an additional subcommand `knife linode server show` that spits out details of a linode instance. Because linode does not provide any metadata service, this command can be used to build tooling that needs linode metadata.
