### PR TITLE
Add support for encrypted data bag secrets.

### DIFF
--- a/lib/chef/knife/linode_server_create.rb
+++ b/lib/chef/knife/linode_server_create.rb
@@ -147,6 +147,17 @@ class Chef
            Chef::Config[:knife][:hints][name] = path ? JSON.parse(::File.read(path)) : Hash.new
         }
 
+      option :secret,
+        :short => "-s SECRET",
+        :long  => "--secret ",
+        :description => "The secret key to use to encrypt data bag item values",
+        :proc => Proc.new { |s| Chef::Config[:knife][:secret] = s }
+
+      option :secret_file,
+        :long => "--secret-file SECRET_FILE",
+        :description => "A file containing the secret key to use to encrypt data bag item values",
+        :proc => Proc.new { |sf| Chef::Config[:knife][:secret_file] = sf }
+
       def tcp_test_ssh(hostname)
         Chef::Log.debug("testing ssh connection to #{hostname}")
         tcp_socket = TCPSocket.new(hostname, 22)
@@ -258,6 +269,8 @@ class Chef
         bootstrap.config[:template_file] = locate_config_value(:template_file)
         bootstrap.config[:environment] = config[:environment]
         bootstrap.config[:host_key_verify] = config[:host_key_verify]
+        bootstrap.config[:secret] = locate_config_value(:secret)
+        bootstrap.config[:secret_file] = locate_config_value(:secret_file)
         bootstrap
       end
 


### PR DESCRIPTION
This will pass the `--secret` and `--secret-file` options to
`Chef::Knife::Bootstrap` to be on par with other cloud Knife plugins.
