### PR TITLE
[Regression] Ensure that Chef::Config[:knife][:hints]['linode'] exists.

### DIFF
--- a/lib/chef/knife/linode_server_create.rb
+++ b/lib/chef/knife/linode_server_create.rb
@@ -230,6 +230,7 @@ class Chef
           puts("done")
         }
 
+        Chef::Config[:knife][:hints]['linode'] ||= Hash.new
         Chef::Config[:knife][:hints]['linode'].merge!({
             'server_id' => server.id.to_s,
             'datacenter_id' => locate_config_value(:linode_datacenter),


### PR DESCRIPTION
In a version of Chef between 11.6.0 and 11.8.2 the options default
behavior changed such that the linode hints hash was not initialized,
causing an "undefined method `merge!' for nil:NilClass'`" error to be
raised when creating a server with Chef 11.8.2.

This fix guards against the linode hash being nil just before the
in-place merge operation occurs. Is backwards compatible with prior
versions of Chef that worked with the previous option logic.
