### PR TITLE
add public_ip and private_ip too bootstrap config

### DIFF
--- a/lib/chef/knife/linode_server_create.rb
+++ b/lib/chef/knife/linode_server_create.rb
@@ -272,6 +272,8 @@ class Chef
         bootstrap.config[:host_key_verify] = config[:host_key_verify]
         bootstrap.config[:secret] = locate_config_value(:secret)
         bootstrap.config[:secret_file] = locate_config_value(:secret_file)
+        bootstrap.config[:private_ip] = server.ips.reject{ |ip| ip.public }.first.ip
+        bootstrap.config[:public_ip] = server.public_ip_address
         bootstrap
       end
 


### PR DESCRIPTION
This allows configuring networking from a bootstrap template, because linode doesn't do this automatically for whatever reason..
To implement this you would add something like [this](https://gist.github.com/jblancett/6c4e3457a03614c22a27) to your bootstrap template.
