### PR TITLE
update default image

### DIFF
--- a/lib/chef/knife/linode_server_create.rb
+++ b/lib/chef/knife/linode_server_create.rb
@@ -50,7 +50,7 @@ class Chef
         :long => "--linode-image IMAGE",
         :description => "The image for the server",
         :proc => Proc.new { |i| Chef::Config[:knife][:linode_image] = i },
-        :default => 99 # Ubuntu 12.04 LTS
+        :default => 124 # Ubuntu 14.04 LTS
 
       option :linode_kernel,
         :short => "-k KERNEL",


### PR DESCRIPTION
99 is an invalid image ID.  So by default, server create throws this error:
ERROR: ArgumentError: Initialization parameters must be an attributes hash, got NilClass nil

The ID for Ubuntu 12.04 is now 126.

I figured it was time for an upgrade though and set it to Ubuntu 14.04, can change it back to 12.04 with the correct ID if that is preferred
