### PR TITLE
missing server throwing wrong exception

### DIFF
--- a/lib/chef/knife/linode_server_delete.rb
+++ b/lib/chef/knife/linode_server_delete.rb
@@ -70,6 +70,7 @@ class Chef
             server = connection.servers.detect do |s|
               s.id.to_s == linode_id || s.name == linode_id
             end
+            raise Fog::Compute::Linode::NotFound.new unless server
             delete_id = server.id
 
             msg_pair("Linode ID", server.id.to_s)


### PR DESCRIPTION
When there is no matching server, an exception is raised that is not caught by the rescue.
I'm assuming this is a remnant from before deleting by label name was added.
Linode's api only lets you filter servers by ID, so instead it is pulling a full server list and filtering for a match.
When there is no match, server = nil so when it tries to get server.id it raises:
NoMethodError: undefined method `id' for nil:NilClass
So instead I'm faking the linode error so the delete request further down can still be caught by the same error, if that happens.  Open to other solutions
