### PR TITLE
use the correct reference to server client and node on purge

### DIFF
--- a/lib/chef/knife/linode_server_delete.rb
+++ b/lib/chef/knife/linode_server_delete.rb
@@ -89,7 +89,7 @@ class Chef
               if config[:chef_node_name]
                 thing_to_delete = config[:chef_node_name]
               else
-                thing_to_delete = server.name
+                thing_to_delete = delete_id
               end
               destroy_item(Chef::Node, thing_to_delete, "node")
               destroy_item(Chef::ApiClient, thing_to_delete, "client")


### PR DESCRIPTION
Delete the node by the server's ID rather than it's name in the case that the server has a name assigned via `--linode-node-name Node-Name`