### PR TITLE
Require Chef 12 / Ruby 2.2.2

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+# Version:
+
+[Version of the project installed]
+
+# Environment: [Details about the environment such as the Operating System, cookbook details, etc...]
+
+# Scenario:
+
+[What you are trying to achieve and you can't?]
+
+# Steps to Reproduce:
+
+[If you are filing an issue what are the things we need to do in order to repro your problem?]
+
+# Expected Result:
+
+[What are you expecting to happen as the consequence of above reproduction steps?]
+
+# Actual Result:
+
+[What actually happens after the reproduction steps?]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,23 @@
-pkg/*
+*.gem
+*.rbc
+.bundle
+.config
+coverage
+InstalledFiles
+lib/bundler/man
+pkg
+rdoc
+spec/reports
+test/tmp
+test/version_tmp
+tmp
+
+# YARD artifacts
+.yardoc
+_yardoc
+doc/
+.swp
+.swo
 Gemfile.lock
-.rspec
+.rvmrc
+.ruby-version

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--color
+-fdocumentation
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,4 @@ rvm:
 branches:
   only:
   - master
-
-  - bundle exec rake
+script: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
+language: ruby
+cache: bundler
+sudo: false
 rvm:
-  - 2.0.0
-script:
-#  - bundle exec rubocop .
-  - bundle exec rspec --color --format progress
+- 2.2.5
+- 2.3.1
+branches:
+  only:
+  - master
+
+  - bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,9 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in knife-linode.gemspec
 gemspec
 
-gem "pry"
-gem "rspec", "~> 3.0"
-gem "chefstyle"
-gem "rake", "~> 11.0"
+group :development do
+  gem "pry"
+  gem "rspec", "~> 3.0"
+  gem "chefstyle"
+  gem "rake", "~> 11.0"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in knife-linode.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in knife-linode.gemspec
 gemspec
+
+gem "pry"
+gem "rspec", "~> 3.0"
+gem "chefstyle"
+gem "rake", "~> 11.0"

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ In-depth usage instructions can be found on the [Chef Docs](http://docs.opscode.
 
 ### Requirements
 
-* Chef 11.8.x or higher
-* Ruby 2.0.x or higher 
+* Chef 12.0 higher
+* Ruby 2.2.2 or higher 
 
 ### Installation
 
@@ -20,7 +20,7 @@ This plugin is distributed as a Ruby Gem. To install it, run:
 
 Or use bundler:
 
-    gem 'knife-linode', '~> 0.3'
+    gem 'knife-linode'
 
 Depending on your system's configuration, you may need to run this command
 with root privileges.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Knife Linode
 
+[![Gem Version](https://badge.fury.io/rb/knife-linode.svg)](https://rubygems.org/gems/knife-linode) [![Build Status](https://travis-ci.org/chef/knife-linode.svg?branch=master)](https://travis-ci.org/chef/knife-linode)
+
 ## Description
 
 This is the official Chef Knife plugin for Linode. This plugin gives knife the ability to create, bootstrap, and manage Linode instances.
@@ -11,16 +13,22 @@ This is the official Chef Knife plugin for Linode. This plugin gives knife the a
 
 ## Installation
 
-This plugin is distributed as a Ruby Gem. To install it, run:
+If you're using [ChefDK](https://downloads.chef.io/chef-dk/), simply install the Gem:
 
-```
-gem install knife-linode
+```bash
+$ chef gem install knife-linode
 ```
 
-Or use bundler:
+If you're using bundler, simply add Chef and Knife Linode to your `Gemfile`:
 
-```
+```ruby
 gem 'knife-linode'
+```
+
+If you are not using bundler, you can install the gem manually from Rubygems:
+
+```bash
+$ gem install knife-linode
 ```
 
 Depending on your system's configuration, you may need to run this command with root privileges.
@@ -29,13 +37,13 @@ Depending on your system's configuration, you may need to run this command with 
 
 In order to communicate with the Linode API you will have to tell Knife about your Linode API Key. The easiest way to accomplish this is to create some entries in your `knife.rb` file:
 
-```
+```ruby
 knife[:linode_api_key] = "Your Linode API Key"
 ```
 
 If your knife.rb file will be checked into a SCM system (ie readable by others) you may want to read the values from environment variables:
 
-```
+```ruby
 knife[:linode_api_key] = "#{ENV['LINODE_API_KEY']}"
 ```
 
@@ -56,7 +64,7 @@ Additionally the following options may be set in your `knife.rb`:
 - distro
 - template_file
 
-# Sub Commands
+## Knife Sub Commands
 
 This plugin provides the following Knife subcommands. Specific command options can be found by invoking the subcommand with a `--help` flag
 
@@ -65,50 +73,55 @@ This plugin provides the following Knife subcommands. Specific command options c
 Provisions a new server in Linode and then perform a Chef bootstrap (using the SSH protocol). The goal of the bootstrap is to get Chef installed on the target system so it can run Chef Client with a Chef Server. The main assumption is a baseline OS installation exists (provided by the provisioning). It is primarily intended for Chef Client systems that talk to a Chef server. By default the server is bootstrapped using the [ubuntu10.04-gems](https://github.com/opscode/chef/blob/master/chef/lib/chef/k
 nife/bootstrap/ubuntu10.04-gems.erb) template. This can be overridden using the `-d` or `--template-file` command options.
 
-## knife linode server delete
+### knife linode server delete
 
 Deletes an existing server in the currently configured Linode account. **PLEASE NOTE** - this does not delete the associated node and client objects from the Chef server.
 
-## knife linode server list
+### knife linode server list
 
 Outputs a list of all servers in the currently configured Linode account. **PLEASE NOTE** - this shows all instances associated with the account, some of which may not be currently managed by the Chef server.
 
-## knife linode server reboot
+### knife linode server reboot
 
 Reboots an existing server in the currently configured Linode account.
 
-## knife linode datacenter list
+### knife linode datacenter list
 
 View a list of available data centers, listed by data center ID and location.
 
-## knife linode flavor list
+### knife linode flavor list
 
 View a list of servers from the Linode environment, listed by ID, name, RAM, disk, and Price.
 
-## knife linode image list
+### knife linode image list
 
 View a list of images from the Linode environment, listed by ID, name, bits, and image size.
 
-## knife linode kernel list
+### knife linode kernel list
 
 View a a list of available kernels, listed by ID and name.
 
-## knife linode stackscript list
+### knife linode stackscript list
 
 View a list of Linode StackScripts that are currently being used.
 
-# License
+## License and Authors
 
-Apache License, Version 2.0
+- Author:: Adam Jacob ([adam@chef.io](mailto:adam@chef.io))
+- Author:: Jesse Adams ([jesse@techno-geeks.org](mailto:jesse@techno-geeks.org))
 
-Original Author: Adam Jacob ([adam@chef.io](mailto:adam@chef.io))
+```text
+Copyright 2009-2016 Chef Software, Inc.
 
-Copyright (c) 2009-2016 Chef Software, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
 
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 ```
-http://www.apache.org/licenses/LICENSE-2.0
-```
-
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,135 +1,114 @@
-## Knife Linode
+# Knife Linode
 
-### Description
+## Description
 
-This is the official Opscode Knife plugin for Linode. This plugin gives knife
-the ability to create, bootstrap, and manage Linode instances.
+This is the official Chef Knife plugin for Linode. This plugin gives knife the ability to create, bootstrap, and manage Linode instances.
 
-In-depth usage instructions can be found on the [Chef Docs](http://docs.opscode.com/plugin_knife_linode.html).
+## Requirements
 
-### Requirements
+- Chef 12.0 higher
+- Ruby 2.2.2 or higher
 
-* Chef 12.0 higher
-* Ruby 2.2.2 or higher 
-
-### Installation
+## Installation
 
 This plugin is distributed as a Ruby Gem. To install it, run:
 
-    gem install knife-linode
+```
+gem install knife-linode
+```
 
 Or use bundler:
 
-    gem 'knife-linode'
+```
+gem 'knife-linode'
+```
 
-Depending on your system's configuration, you may need to run this command
-with root privileges.
+Depending on your system's configuration, you may need to run this command with root privileges.
 
-### Configuration
+## Configuration
 
-In order to communicate with the Linode API you will have to tell Knife about
-your Linode API Key.  The easiest way to accomplish this is to create some
-entries in your `knife.rb` file:
+In order to communicate with the Linode API you will have to tell Knife about your Linode API Key. The easiest way to accomplish this is to create some entries in your `knife.rb` file:
 
-    knife[:linode_api_key] = "Your Linode API Key"
+```
+knife[:linode_api_key] = "Your Linode API Key"
+```
 
-If your knife.rb file will be checked into a SCM system (ie readable by
-others) you may want to read the values from environment variables:
+If your knife.rb file will be checked into a SCM system (ie readable by others) you may want to read the values from environment variables:
 
-    knife[:linode_api_key] = "#{ENV['LINODE_API_KEY']}"
+```
+knife[:linode_api_key] = "#{ENV['LINODE_API_KEY']}"
+```
 
-You also have the option of passing your Linode API Key into the individual
-knife subcommands using the `-A` (or `--linode-api-key`) command option
+You also have the option of passing your Linode API Key into the individual knife subcommands using the `-A` (or `--linode-api-key`) command option
 
-    # Provision a new 1 GB 64 bit Ubuntu 14.04 Linode in the Dallas, TX datacenter
-    knife linode server create -r 'role[webserver]' --linode-image 124 --linode-datacenter 2 --linode-flavor 1 --linode-node-name YOUR_LINODE_NODE_NAME
+```
+# Provision a new 1 GB 64 bit Ubuntu 14.04 Linode in the Dallas, TX datacenter
+knife linode server create -r 'role[webserver]' --linode-image 124 --linode-datacenter 2 --linode-flavor 1 --linode-node-name YOUR_LINODE_NODE_NAME
+```
 
 Additionally the following options may be set in your `knife.rb`:
 
-*   linode_flavor
-*   linode_image
-*   linode_kernel
-*   ssh_password
-*   bootstrap_version
-*   distro
-*   template_file
+- linode_flavor
+- linode_image
+- linode_kernel
+- ssh_password
+- bootstrap_version
+- distro
+- template_file
 
-## Sub Commands
+# Sub Commands
 
-This plugin provides the following Knife subcommands.  Specific command
-options can be found by invoking the subcommand with a `--help` flag
+This plugin provides the following Knife subcommands. Specific command options can be found by invoking the subcommand with a `--help` flag
 
-### knife linode server create
+## knife linode server create
 
-Provisions a new server in Linode and then perform a Chef bootstrap (using the
-SSH protocol).  The goal of the bootstrap is to get Chef installed on the
-target system so it can run Chef Client with a Chef Server. The main
-assumption is a baseline OS installation exists (provided by the
-provisioning). It is primarily intended for Chef Client systems that talk to a
-Chef server.  By default the server is bootstrapped using the
-[ubuntu10.04-gems](https://github.com/opscode/chef/blob/master/chef/lib/chef/k
-nife/bootstrap/ubuntu10.04-gems.erb) template.  This can be overridden using
-the `-d` or `--template-file` command options.
+Provisions a new server in Linode and then perform a Chef bootstrap (using the SSH protocol). The goal of the bootstrap is to get Chef installed on the target system so it can run Chef Client with a Chef Server. The main assumption is a baseline OS installation exists (provided by the provisioning). It is primarily intended for Chef Client systems that talk to a Chef server. By default the server is bootstrapped using the [ubuntu10.04-gems](https://github.com/opscode/chef/blob/master/chef/lib/chef/k
+nife/bootstrap/ubuntu10.04-gems.erb) template. This can be overridden using the `-d` or `--template-file` command options.
 
-### knife linode server delete
+## knife linode server delete
 
-Deletes an existing server in the currently configured Linode account.
-**PLEASE NOTE** - this does not delete the associated node and client objects
-from the Chef server.
+Deletes an existing server in the currently configured Linode account. **PLEASE NOTE** - this does not delete the associated node and client objects from the Chef server.
 
-### knife linode server list
+## knife linode server list
 
-Outputs a list of all servers in the currently configured Linode account.
-**PLEASE NOTE** - this shows all instances associated with the account, some
-of which may not be currently managed by the Chef server.
+Outputs a list of all servers in the currently configured Linode account. **PLEASE NOTE** - this shows all instances associated with the account, some of which may not be currently managed by the Chef server.
 
-### knife linode server reboot
+## knife linode server reboot
 
 Reboots an existing server in the currently configured Linode account.
 
-### knife linode datacenter list
+## knife linode datacenter list
 
 View a list of available data centers, listed by data center ID and location.
 
-### knife linode flavor list
+## knife linode flavor list
 
-View a list of servers from the Linode environment, listed by ID, name, RAM,
-disk, and Price.
+View a list of servers from the Linode environment, listed by ID, name, RAM, disk, and Price.
 
-### knife linode image list
+## knife linode image list
 
-View a list of images from the Linode environment, listed by ID, name, bits,
-and image size.
+View a list of images from the Linode environment, listed by ID, name, bits, and image size.
 
-### knife linode kernel list
+## knife linode kernel list
 
 View a a list of available kernels, listed by ID and name.
 
-### knife linode stackscript list
+## knife linode stackscript list
 
 View a list of Linode StackScripts that are currently being used.
 
-## License
+# License
 
 Apache License, Version 2.0
 
-Original Author: Adam Jacob (<adam@opscode.com>)
+Original Author: Adam Jacob ([adam@chef.io](mailto:adam@chef.io))
 
-Copyright (c) 2009-2014 Opscode, Inc.
+Copyright (c) 2009-2016 Chef Software, Inc.
 
-Licensed under the Apache License, Version 2.0 (the "License"); you may not
-use this file except in compliance with the License. You may obtain a copy of
-the License at
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+```
+http://www.apache.org/licenses/LICENSE-2.0
+```
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-License for the specific language governing permissions and limitations under
-the License.
-
-## Maintainers
-
-* Jesse R. Adams ([jesseadams](https://github.com/jesseadams))
-* You?
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -13,27 +13,15 @@ This is the official Chef Knife plugin for Linode. This plugin gives knife the a
 
 ## Installation
 
-If you're using [ChefDK](https://downloads.chef.io/chef-dk/), simply install the Gem:
+Using [ChefDK](https://downloads.chef.io/chef-dk/), simply install the Gem:
 
 ```bash
 $ chef gem install knife-linode
 ```
 
-If you're using bundler, simply add Chef and Knife Linode to your `Gemfile`:
-
-```ruby
-gem 'knife-linode'
-```
-
-If you are not using bundler, you can install the gem manually from Rubygems:
-
-```bash
-$ gem install knife-linode
-```
-
-Depending on your system's configuration, you may need to run this command with root privileges.
-
 ## Configuration
+
+### knife.rb
 
 In order to communicate with the Linode API you will have to tell Knife about your Linode API Key. The easiest way to accomplish this is to create some entries in your `knife.rb` file:
 
@@ -68,7 +56,7 @@ Additionally the following options may be set in your `knife.rb`:
 
 This plugin provides the following Knife subcommands. Specific command options can be found by invoking the subcommand with a `--help` flag
 
-## knife linode server create
+### knife linode server create
 
 Provisions a new server in Linode and then perform a Chef bootstrap (using the SSH protocol). The goal of the bootstrap is to get Chef installed on the target system so it can run Chef Client with a Chef Server. The main assumption is a baseline OS installation exists (provided by the provisioning). It is primarily intended for Chef Client systems that talk to a Chef server. By default the server is bootstrapped using the [ubuntu10.04-gems](https://github.com/opscode/chef/blob/master/chef/lib/chef/k
 nife/bootstrap/ubuntu10.04-gems.erb) template. This can be overridden using the `-d` or `--template-file` command options.
@@ -104,6 +92,10 @@ View a a list of available kernels, listed by ID and name.
 ### knife linode stackscript list
 
 View a list of Linode StackScripts that are currently being used.
+
+## Contributing
+
+For information on contributing to this project see <https://github.com/chef/chef/blob/master/CONTRIBUTING.md>
 
 ## License and Authors
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,24 @@
 require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+begin
+  require "rspec/core/rake_task"
 
-RSpec::Core::RakeTask.new(:spec)
+  desc "Run all specs in spec directory"
+  RSpec::Core::RakeTask.new(:spec) do |t|
+    t.pattern = "spec/unit/**/*_spec.rb"
+  end
 
-require "chefstyle"
-require "rubocop/rake_task"
-RuboCop::RakeTask.new(:style) do |task|
-  task.options << "--display-cop-names"
+rescue LoadError
+  STDERR.puts "\n*** RSpec not available. (sudo) gem install rspec to run unit tests. ***\n\n"
+end
+
+begin
+  require "chefstyle"
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new(:style) do |task|
+    task.options << "--display-cop-names"
+  end
+rescue LoadError
+  STDERR.puts "\n*** chefstyle not available. (sudo) gem install chefstyle to run unit tests. ***\n\n"
 end
 
 task default: [:spec, :style]

--- a/Rakefile
+++ b/Rakefile
@@ -1,56 +1,12 @@
-#
-# Author:: Adam Jacob (<adam@opscode.com>)
-# Author:: Daniel DeLeo (<dan@opscode.com>)
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
-# Copyright:: Copyright (c) 2008, 2010 Opscode, Inc.
-# License:: Apache License, Version 2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
 
-require 'bundler'
-Bundler::GemHelper.install_tasks
+RSpec::Core::RakeTask.new(:spec)
 
-# require 'rubygems'
-# require 'rake/gempackagetask'
-require 'rake/rdoctask'
-
-begin
-  require 'sdoc'
-
-  Rake::RDocTask.new do |rdoc|
-    rdoc.title = "Chef Ruby API Documentation"
-    rdoc.main = "README.rdoc"
-    rdoc.options << '--fmt' << 'shtml' # explictly set shtml generator
-    rdoc.template = 'direct' # lighter template
-    rdoc.rdoc_files.include("README.rdoc", "LICENSE", "spec/tiny_server.rb", "lib/**/*.rb")
-    rdoc.rdoc_dir = "rdoc"
-  end
-rescue LoadError
-  puts "sdoc is not available. (sudo) gem install sdoc to generate rdoc documentation."
+require "chefstyle"
+require "rubocop/rake_task"
+RuboCop::RakeTask.new(:style) do |task|
+  task.options << "--display-cop-names"
 end
 
-begin
-  require 'rspec/core/rake_task'
-
-  task :default => :spec
-
-  desc "Run all specs in spec directory"
-  RSpec::Core::RakeTask.new(:spec) do |t|
-    t.pattern = 'spec/unit/**/*_spec.rb'
-  end
-
-rescue LoadError
-  STDERR.puts "\n*** RSpec not available. (sudo) gem install rspec to run unit tests. ***\n\n"
-end
-
+task default: [:spec, :style]

--- a/knife-linode.gemspec
+++ b/knife-linode.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |s|
   s.name        = "knife-linode"
   s.version     = Knife::Linode::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Adam Jacob", "Seth Chisamore", "Lamont Granquist"]
-  s.email       = ["adam@chef.io", "schisamo@chef.io", "lamont@chef.io"]
+  s.authors     = ["Adam Jacob", "Seth Chisamore", "Lamont Granquist", "Jesse R. Adams"]
+  s.email       = ["adam@chef.io", "schisamo@chef.io", "lamont@chef.io", "jesse@techno-geeks.org"]
   s.license     = "Apache-2.0"
   s.has_rdoc    = true
   s.homepage    = "https://github.com/chef/knife-linode"

--- a/knife-linode.gemspec
+++ b/knife-linode.gemspec
@@ -6,24 +6,24 @@ Gem::Specification.new do |s|
   s.name        = "knife-linode"
   s.version     = Knife::Linode::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ['Adam Jacob', 'Seth Chisamore', 'Lamont Granquist']
-  s.email       = ['adam@chef.io', 'schisamo@chef.io', 'lamont@chef.io']
+  s.authors     = ["Adam Jacob", "Seth Chisamore", "Lamont Granquist"]
+  s.email       = ["adam@chef.io", "schisamo@chef.io", "lamont@chef.io"]
   s.license     = "Apache-2.0"
   s.has_rdoc    = true
-  s.homepage    = 'https://github.com/chef/knife-linode'
+  s.homepage    = "https://github.com/chef/knife-linode"
   s.summary     = "Linode Support for Chef's Knife Command"
   s.description = s.summary
-  s.extra_rdoc_files = ['README.md', 'LICENSE']
+  s.extra_rdoc_files = ["README.md", "LICENSE"]
 
   s.required_ruby_version = ">= 2.2.2"
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "fog",  "~> 1.0"
   s.add_runtime_dependency "chef", ">= 12.0"
 
-  s.add_development_dependency "rspec",   "~> 3.0"
+  s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "chefstyle"
 end

--- a/knife-linode.gemspec
+++ b/knife-linode.gemspec
@@ -5,21 +5,25 @@ require "knife-linode/version"
 Gem::Specification.new do |s|
   s.name        = "knife-linode"
   s.version     = Knife::Linode::VERSION
-  s.authors     = ['Adam Jacob', 'Seth Chisamore', 'Lamont Granquist', 'Jesse R. Adams']
-  s.email       = ['adam@opscode.com', 'schisamo@opscode.com', 'lamont@opscode.com', 'jesse@techno-geeks.org']
-  s.homepage    = 'http://wiki.opscode.com/display/chef'
+  s.platform    = Gem::Platform::RUBY
+  s.authors     = ['Adam Jacob', 'Seth Chisamore', 'Lamont Granquist']
+  s.email       = ['adam@chef.io', 'schisamo@chef.io', 'lamont@chef.io']
+  s.license     = "Apache-2.0"
+  s.has_rdoc    = true
+  s.homepage    = 'https://github.com/chef/knife-linode'
   s.summary     = "Linode Support for Chef's Knife Command"
   s.description = s.summary
   s.extra_rdoc_files = ['README.md', 'LICENSE']
 
+  s.required_ruby_version = ">= 2.2.2"
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "fog",  "~> 1.0"
-  s.add_runtime_dependency "chef", ">= 11.8"
+  s.add_runtime_dependency "chef", ">= 12.0"
 
   s.add_development_dependency "rspec",   "~> 3.0"
-  s.add_development_dependency "rubocop",    "~> 0.24"
+  s.add_development_dependency "chefstyle"
 end

--- a/knife-linode.gemspec
+++ b/knife-linode.gemspec
@@ -23,8 +23,4 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "fog",  "~> 1.0"
   s.add_runtime_dependency "chef", ">= 12.0"
-
-  s.add_development_dependency "rspec", "~> 3.0"
-  s.add_development_dependency "chefstyle"
-  s.add_development_dependency "rake", "~> 11.0"
 end

--- a/knife-linode.gemspec
+++ b/knife-linode.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "chefstyle"
+  s.add_development_dependency "rake", "~> 11.0"
 end

--- a/lib/chef/knife/linode_base.rb
+++ b/lib/chef/knife/linode_base.rb
@@ -1,7 +1,7 @@
 #
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
-# Author:: Lamont Granquist (<lamont@opscode.com>)
-# Copyright:: Copyright (c) 2011 Opscode, Inc.
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Lamont Granquist (<lamont@chef.io>)
+# Copyright:: Copyright (c) 2011-2016 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/linode_base.rb
+++ b/lib/chef/knife/linode_base.rb
@@ -70,7 +70,7 @@ class Chef
         keys.each do |k|
           pretty_key = k.to_s.tr("_", " ").gsub(/\w+/) { |w| (w =~ /(api)/i) ? w.upcase : w.capitalize }
           if Chef::Config[:knife][k].nil?
-            errors << "You did not provide a valid '#{pretty_key}' value."
+            errors << "You did not provide a valid '#{pretty_key}' value in your knife as #{k}."
           end
         end
 

--- a/lib/chef/knife/linode_base.rb
+++ b/lib/chef/knife/linode_base.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require 'chef/knife'
+require "chef/knife"
 
 class Chef
   class Knife
@@ -30,9 +30,9 @@ class Chef
         includer.class_eval do
 
           deps do
-            require 'fog'
-            require 'readline'
-            require 'chef/json_compat'
+            require "fog"
+            require "readline"
+            require "chef/json_compat"
           end
 
           option :linode_api_key,
@@ -47,7 +47,7 @@ class Chef
       def connection
         @connection ||= begin
           connection = Fog::Compute.new(
-            :provider => 'Linode',
+            :provider => "Linode",
             :linode_api_key => Chef::Config[:knife][:linode_api_key]
           )
         end
@@ -58,23 +58,23 @@ class Chef
         config[key] || Chef::Config[:knife][key]
       end
 
-      def msg_pair(label, value, color=:cyan)
+      def msg_pair(label, value, color = :cyan)
         if value && !value.empty?
           puts "#{ui.color(label, color)}: #{value}"
         end
       end
 
-      def validate!(keys=[:linode_api_key])
+      def validate!(keys = [:linode_api_key])
         errors = []
 
         keys.each do |k|
-          pretty_key = k.to_s.gsub(/_/, ' ').gsub(/\w+/){ |w| (w =~ /(api)/i) ? w.upcase  : w.capitalize }
+          pretty_key = k.to_s.tr("_", " ").gsub(/\w+/) { |w| (w =~ /(api)/i) ? w.upcase : w.capitalize }
           if Chef::Config[:knife][k].nil?
             errors << "You did not provide a valid '#{pretty_key}' value."
           end
         end
 
-        if errors.each{|e| ui.error(e)}.any?
+        if errors.each { |e| ui.error(e) }.any?
           exit 1
         end
       end
@@ -101,4 +101,3 @@ class Chef
     end
   end
 end
-

--- a/lib/chef/knife/linode_datacenter_list.rb
+++ b/lib/chef/knife/linode_datacenter_list.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require 'chef/knife/linode_base'
+require "chef/knife/linode_base"
 
 class Chef
   class Knife
@@ -29,11 +29,10 @@ class Chef
       banner "knife linode datacenter list (options)"
 
       def run
-
         validate!
         server_list = [
-          ui.color('ID', :bold),
-          ui.color('Location', :bold),
+          ui.color("ID", :bold),
+          ui.color("Location", :bold),
         ]
 
         connection.data_centers.each do |datacenter|
@@ -42,7 +41,6 @@ class Chef
         end
 
         puts ui.list(server_list, :columns_across, 2)
-
       end
     end
   end

--- a/lib/chef/knife/linode_datacenter_list.rb
+++ b/lib/chef/knife/linode_datacenter_list.rb
@@ -1,8 +1,8 @@
 
-# Author:: Adam Jacob (<adam@opscode.com>)
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
-# Author:: Lamont Granquist (<lamont@opscode.com>)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Author:: Adam Jacob (<adam@chef.io>)
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Lamont Granquist (<lamont@chef.io>)
+# Copyright:: Copyright (c) 2010-2016 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/linode_flavor_list.rb
+++ b/lib/chef/knife/linode_flavor_list.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require 'chef/knife/linode_base'
+require "chef/knife/linode_base"
 
 class Chef
   class Knife
@@ -29,15 +29,14 @@ class Chef
       banner "knife linode flavor list (options)"
 
       def run
-
         validate!
 
         server_list = [
-          ui.color('ID', :bold),
-          ui.color('Name', :bold),
-          ui.color('RAM', :bold),
-          ui.color('Disk', :bold),
-          ui.color('Price', :bold),
+          ui.color("ID", :bold),
+          ui.color("Name", :bold),
+          ui.color("RAM", :bold),
+          ui.color("Disk", :bold),
+          ui.color("Price", :bold),
         ]
 
         connection.flavors.each do |flavor|
@@ -49,7 +48,6 @@ class Chef
         end
 
         puts ui.list(server_list, :columns_across, 5)
-
       end
     end
   end

--- a/lib/chef/knife/linode_flavor_list.rb
+++ b/lib/chef/knife/linode_flavor_list.rb
@@ -1,8 +1,8 @@
 
-# Author:: Adam Jacob (<adam@opscode.com>)
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
-# Author:: Lamont Granquist (<lamont@opscode.com>)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Author:: Adam Jacob (<adam@chef.io>)
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Lamont Granquist (<lamont@chef.io>)
+# Copyright:: Copyright (c) 2010-2016 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/linode_image_list.rb
+++ b/lib/chef/knife/linode_image_list.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require 'chef/knife/linode_base'
+require "chef/knife/linode_base"
 
 class Chef
   class Knife
@@ -29,14 +29,13 @@ class Chef
       banner "knife linode image list (options)"
 
       def run
-
         validate!
 
         server_list = [
-          ui.color('ID', :bold),
-          ui.color('Name', :bold),
-          ui.color('Bits', :bold),
-          ui.color('Image Size', :bold),
+          ui.color("ID", :bold),
+          ui.color("Name", :bold),
+          ui.color("Bits", :bold),
+          ui.color("Image Size", :bold),
         ]
 
         connection.images.each do |image|
@@ -47,7 +46,6 @@ class Chef
         end
 
         puts ui.list(server_list, :columns_across, 4)
-
       end
     end
   end

--- a/lib/chef/knife/linode_image_list.rb
+++ b/lib/chef/knife/linode_image_list.rb
@@ -1,8 +1,8 @@
 
-# Author:: Adam Jacob (<adam@opscode.com>)
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
-# Author:: Lamont Granquist (<lamont@opscode.com>)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Author:: Adam Jacob (<adam@chef.io>)
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Lamont Granquist (<lamont@chef.io>)
+# Copyright:: Copyright (c) 2010-2016 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/linode_kernel_list.rb
+++ b/lib/chef/knife/linode_kernel_list.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require 'chef/knife/linode_base'
+require "chef/knife/linode_base"
 
 class Chef
   class Knife
@@ -29,12 +29,11 @@ class Chef
       banner "knife linode kernel list (options)"
 
       def run
-
         validate!
 
         server_list = [
-          ui.color('ID', :bold),
-          ui.color('Name', :bold),
+          ui.color("ID", :bold),
+          ui.color("Name", :bold),
         ]
 
         connection.kernels.each do |kernel|
@@ -43,7 +42,6 @@ class Chef
         end
 
         puts ui.list(server_list, :columns_across, 2)
-
       end
     end
   end

--- a/lib/chef/knife/linode_kernel_list.rb
+++ b/lib/chef/knife/linode_kernel_list.rb
@@ -1,8 +1,8 @@
 
-# Author:: Adam Jacob (<adam@opscode.com>)
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
-# Author:: Lamont Granquist (<lamont@opscode.com>)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Author:: Adam Jacob (<adam@chef.io>)
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Lamont Granquist (<lamont@chef.io>)
+# Copyright:: Copyright (c) 2010-2016 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/linode_server_create.rb
+++ b/lib/chef/knife/linode_server_create.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require 'chef/knife/linode_base'
+require "chef/knife/linode_base"
 
 class Chef
   class Knife
@@ -26,13 +26,13 @@ class Chef
 
       include Knife::LinodeBase
 
-       deps do
-         require 'fog'
-         require 'readline'
-         require 'chef/json_compat'
-         require 'chef/knife/bootstrap'
-         Chef::Knife::Bootstrap.load_deps
-       end
+      deps do
+        require "fog"
+        require "readline"
+        require "chef/json_compat"
+        require "chef/knife/bootstrap"
+        Chef::Knife::Bootstrap.load_deps
+      end
 
       banner "knife linode server create (options)"
 
@@ -83,7 +83,7 @@ class Chef
         :default => "root"
 
       chars = ("a".."z").to_a + ("1".."9").to_a + ("A".."Z").to_a
-      @@defpass = Array.new(20, '').collect{chars[rand(chars.size)]}.push('A').push('a').join
+      @@defpass = Array.new(20, "").collect { chars[rand(chars.size)] }.push("A").push("a").join
 
       option :ssh_password,
         :short => "-P PASSWORD",
@@ -138,13 +138,13 @@ class Chef
         :boolean => true,
         :default => true
 
-      Chef::Config[:knife][:hints] ||= {"linode" => {}}
+      Chef::Config[:knife][:hints] ||= { "linode" => {} }
       option :hint,
         :long => "--hint HINT_NAME[=HINT_FILE]",
         :description => "Specify Ohai Hint to be set on the bootstrap target.  Use multiple --hint options to specify multiple hints.",
         :proc => Proc.new { |h|
-           name, path = h.split("=")
-           Chef::Config[:knife][:hints][name] = path ? JSON.parse(::File.read(path)) : Hash.new
+          name, path = h.split("=")
+          Chef::Config[:knife][:hints][name] = path ? JSON.parse(::File.read(path)) : Hash.new
         }
 
       option :secret,
@@ -226,7 +226,7 @@ class Chef
                     :password => locate_config_value(:ssh_password)
                  )
 
-        connection.linode_update(server.id, {:lpm_displaygroup => config[:display_group]}) if config[:display_group]
+        connection.linode_update(server.id, { :lpm_displaygroup => config[:display_group] }) if config[:display_group]
 
         fqdn = server.ips.select { |lip| !( lip.ip =~ /^192\.168\./ || lip.ip =~ /^10\./ || lip.ip =~ /^172\.(1[6-9]|2[0-9]|3[0-1])\./ ) }.first.ip
 
@@ -243,25 +243,25 @@ class Chef
 
         print "\n#{ui.color("Waiting for sshd", :magenta)}"
 
-        print(".") until tcp_test_ssh(fqdn) {
+        print(".") until tcp_test_ssh(fqdn) do
           sleep @initial_sleep_delay ||= 10
           puts("done")
-        }
+        end
 
-        Chef::Config[:knife][:hints]['linode'] ||= Hash.new
-        Chef::Config[:knife][:hints]['linode'].merge!({
-            'server_id' => server.id.to_s,
-            'datacenter_id' => locate_config_value(:linode_datacenter),
-            'flavor_id' => locate_config_value(:linode_flavor),
-            'image_id' => locate_config_value(:linode_image),
-            'kernel_id' => locate_config_value(:linode_kernel),
-            'ip_addresses' => server.ips.map(&:ip)})
+        Chef::Config[:knife][:hints]["linode"] ||= Hash.new
+        Chef::Config[:knife][:hints]["linode"].merge!({
+            "server_id" => server.id.to_s,
+            "datacenter_id" => locate_config_value(:linode_datacenter),
+            "flavor_id" => locate_config_value(:linode_flavor),
+            "image_id" => locate_config_value(:linode_image),
+            "kernel_id" => locate_config_value(:linode_kernel),
+            "ip_addresses" => server.ips.map(&:ip) })
 
         msg_pair("JSON Attributes", config[:json_attributes]) unless !config[:json_attributes] || config[:json_attributes].empty?
-        bootstrap_for_node(server,fqdn).run
+        bootstrap_for_node(server, fqdn).run
       end
 
-      def bootstrap_for_node(server,fqdn)
+      def bootstrap_for_node(server, fqdn)
         bootstrap = Chef::Knife::Bootstrap.new
         bootstrap.name_args = [fqdn]
         bootstrap.config[:run_list] = config[:run_list]
@@ -273,13 +273,13 @@ class Chef
         bootstrap.config[:bootstrap_version] = locate_config_value(:bootstrap_version)
         bootstrap.config[:first_boot_attributes] = locate_config_value(:json_attributes) || {}
         bootstrap.config[:distro] = locate_config_value(:distro)
-        bootstrap.config[:use_sudo] = true unless config[:ssh_user] == 'root'
+        bootstrap.config[:use_sudo] = true unless config[:ssh_user] == "root"
         bootstrap.config[:template_file] = locate_config_value(:template_file)
         bootstrap.config[:environment] = config[:environment]
         bootstrap.config[:host_key_verify] = config[:host_key_verify]
         bootstrap.config[:secret] = locate_config_value(:secret)
         bootstrap.config[:secret_file] = locate_config_value(:secret_file)
-        bootstrap.config[:private_ip] = server.ips.reject{ |ip| ip.public }.first.ip
+        bootstrap.config[:private_ip] = server.ips.reject { |ip| ip.public }.first.ip
         bootstrap.config[:public_ip] = server.public_ip_address
         bootstrap
       end

--- a/lib/chef/knife/linode_server_create.rb
+++ b/lib/chef/knife/linode_server_create.rb
@@ -69,7 +69,8 @@ class Chef
       option :linode_node_name,
         :short => "-L NAME",
         :long => "--linode-node-name NAME",
-        :description => "The Linode node name for your new node"
+        :description => "The Linode node name for your new node",
+        :required => true
 
       option :chef_node_name,
         :short => "-N NAME",
@@ -141,7 +142,7 @@ class Chef
       Chef::Config[:knife][:hints] ||= { "linode" => {} }
       option :hint,
         :long => "--hint HINT_NAME[=HINT_FILE]",
-        :description => "Specify Ohai Hint to be set on the bootstrap target.  Use multiple --hint options to specify multiple hints.",
+        :description => "Specify Ohai Hint to be set on the bootstrap target. Use multiple --hint options to specify multiple hints.",
         :proc => Proc.new { |h|
           name, path = h.split("=")
           Chef::Config[:knife][:hints][name] = path ? JSON.parse(::File.read(path)) : Hash.new

--- a/lib/chef/knife/linode_server_create.rb
+++ b/lib/chef/knife/linode_server_create.rb
@@ -69,8 +69,7 @@ class Chef
       option :linode_node_name,
         :short => "-L NAME",
         :long => "--linode-node-name NAME",
-        :description => "The Linode node name for your new node",
-        :required => true
+        :description => "The Linode node name for your new node"
 
       option :chef_node_name,
         :short => "-N NAME",
@@ -201,6 +200,8 @@ class Chef
         $stdout.sync = true
 
         validate!
+
+        raise "You must provide linode_node_name via the CLI or knife.rb config. See help for details" if locate_config_value(:linode_node_name).nil?
 
         datacenter_id = locate_config_value(:linode_datacenter).to_i
         datacenter = connection.data_centers.select { |dc| dc.id == datacenter_id }.first

--- a/lib/chef/knife/linode_server_create.rb
+++ b/lib/chef/knife/linode_server_create.rb
@@ -1,8 +1,8 @@
 
-# Author:: Adam Jacob (<adam@opscode.com>)
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
-# Author:: Lamont Granquist (<lamont@opscode.com>)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Author:: Adam Jacob (<adam@chef.io>)
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Lamont Granquist (<lamont@chef.io>)
+# Copyright:: Copyright (c) 2010-2016 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/linode_server_delete.rb
+++ b/lib/chef/knife/linode_server_delete.rb
@@ -17,11 +17,11 @@
 # limitations under the License.
 #
 
-require 'chef/knife/linode_base'
+require "chef/knife/linode_base"
 
 # These two are needed for the '--purge' deletion case
-require 'chef/node'
-require 'chef/api_client'
+require "chef/node"
+require "chef/api_client"
 
 class Chef
   class Knife
@@ -61,7 +61,6 @@ class Chef
       end
 
       def run
-
         validate!
 
         @name_args.each do |linode_id|
@@ -101,7 +100,6 @@ class Chef
           end
 
         end
-
       end
     end
   end

--- a/lib/chef/knife/linode_server_delete.rb
+++ b/lib/chef/knife/linode_server_delete.rb
@@ -1,7 +1,7 @@
-# Author:: Adam Jacob (<adam@opscode.com>)
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
-# Author:: Lamont Granquist (<lamont@opscode.com>)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Author:: Adam Jacob (<adam@chef.io>)
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Lamont Granquist (<lamont@chef.io>)
+# Copyright:: Copyright (c) 2010-2016 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/linode_server_list.rb
+++ b/lib/chef/knife/linode_server_list.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require 'chef/knife/linode_base'
+require "chef/knife/linode_base"
 
 class Chef
   class Knife
@@ -29,20 +29,19 @@ class Chef
       banner "knife linode server list (options)"
 
       def run
-
         $stdout.sync = true
 
         validate!
 
         server_list = [
-          ui.color('Linode ID', :bold),
-          ui.color('Name', :bold),
-          ui.color('IPs', :bold),
-          ui.color('Status', :bold),
-          ui.color('Backups', :bold),
-          ui.color('Datacenter', :bold),
+          ui.color("Linode ID", :bold),
+          ui.color("Name", :bold),
+          ui.color("IPs", :bold),
+          ui.color("Status", :bold),
+          ui.color("Backups", :bold),
+          ui.color("Datacenter", :bold),
         ]
-    
+
         dc_location = {}
 
         connection.data_centers.map { |dc| dc_location[dc.id] = dc.location }
@@ -52,7 +51,7 @@ class Chef
           server_list << server.name
           server_list << server.ips.map { |x| x.ip }.join(",")
           server_list << status_to_ui(server.status)
-          server_list << case connection.linode_list(server.id).body['DATA'][0]['BACKUPSENABLED']
+          server_list << case connection.linode_list(server.id).body["DATA"][0]["BACKUPSENABLED"]
                          when 0
                            ui.color("No", :red)
                          when 1
@@ -60,11 +59,10 @@ class Chef
                          else
                            ui.color("UNKNOWN", :yellow)
                          end
-          server_list << dc_location[connection.linode_list(server.id).body['DATA'][0]['DATACENTERID']]
+          server_list << dc_location[connection.linode_list(server.id).body["DATA"][0]["DATACENTERID"]]
         end
 
         puts ui.list(server_list, :columns_across, 6)
-
       end
     end
   end

--- a/lib/chef/knife/linode_server_list.rb
+++ b/lib/chef/knife/linode_server_list.rb
@@ -1,8 +1,8 @@
 
-# Author:: Adam Jacob (<adam@opscode.com>)
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
-# Author:: Lamont Granquist (<lamont@opscode.com>)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Author:: Adam Jacob (<adam@chef.io>)
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Lamont Granquist (<lamont@chef.io>)
+# Copyright:: Copyright (c) 2010-2016 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/linode_server_reboot.rb
+++ b/lib/chef/knife/linode_server_reboot.rb
@@ -1,7 +1,7 @@
-# Author:: Adam Jacob (<adam@opscode.com>)
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
-# Author:: Lamont Granquist (<lamont@opscode.com>)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Author:: Adam Jacob (<adam@chef.io>)
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Lamont Granquist (<lamont@chef.io>)
+# Copyright:: Copyright (c) 2010-2016 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/linode_server_reboot.rb
+++ b/lib/chef/knife/linode_server_reboot.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-require 'chef/knife/linode_base'
- 
+require "chef/knife/linode_base"
+
 class Chef
   class Knife
     class LinodeServerReboot < Chef::Knife
@@ -28,7 +28,6 @@ class Chef
       banner "knife linode server reboot LINODE_ID (options)"
 
       def run
-
         validate!
 
         @name_args.each do |linode_id|
@@ -49,10 +48,9 @@ class Chef
             ui.warn("Rebooted server #{linode_id}")
           rescue Fog::Compute::Linode::NotFound
             ui.error("Could not locate server '#{linode_id}'.")
-	        end
+          end
 
         end
-
       end
     end
   end

--- a/lib/chef/knife/linode_stackscript_list.rb
+++ b/lib/chef/knife/linode_stackscript_list.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require 'chef/knife/linode_base'
+require "chef/knife/linode_base"
 
 class Chef
   class Knife
@@ -29,7 +29,6 @@ class Chef
       banner "knife linode stackscript list (options)"
 
       def run
-
         validate!
 
         server_list = [
@@ -44,7 +43,6 @@ class Chef
         end
 
 #        puts ui.list(server_list, :columns_across, 2)
-
       end
     end
   end

--- a/lib/chef/knife/linode_stackscript_list.rb
+++ b/lib/chef/knife/linode_stackscript_list.rb
@@ -1,8 +1,8 @@
 
-# Author:: Adam Jacob (<adam@opscode.com>)
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
-# Author:: Lamont Granquist (<lamont@opscode.com>)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Author:: Adam Jacob (<adam@chef.io>)
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Lamont Granquist (<lamont@chef.io>)
+# Copyright:: Copyright (c) 2010-2016 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/knife-linode/version.rb
+++ b/lib/knife-linode/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Linode
     VERSION = "0.3.2"
-    MAJOR, MINOR, TINY = VERSION.split('.')
+    MAJOR, MINOR, TINY = VERSION.split(".")
   end
 end

--- a/spec/chef/knife/linode_datacenter_list_spec.rb
+++ b/spec/chef/knife/linode_datacenter_list_spec.rb
@@ -1,10 +1,10 @@
-require 'spec_helper'
-require 'linode_datacenter_list'
+require "spec_helper"
+require "linode_datacenter_list"
 
 describe Chef::Knife::LinodeDatacenterList do
   subject { Chef::Knife::LinodeDatacenterList.new }
 
-  let(:api_key) { 'FAKE_API_KEY' }
+  let(:api_key) { "FAKE_API_KEY" }
 
   before :each do
     Chef::Knife::LinodeDatacenterList.load_deps

--- a/spec/chef/knife/linode_flavor_list_spec.rb
+++ b/spec/chef/knife/linode_flavor_list_spec.rb
@@ -1,10 +1,10 @@
-require 'spec_helper'
-require 'linode_flavor_list'
+require "spec_helper"
+require "linode_flavor_list"
 
 describe Chef::Knife::LinodeFlavorList do
   subject { Chef::Knife::LinodeFlavorList.new }
 
-  let(:api_key) { 'FAKE_API_KEY' }
+  let(:api_key) { "FAKE_API_KEY" }
 
   before :each do
     Chef::Knife::LinodeFlavorList.load_deps

--- a/spec/chef/knife/linode_server_create_spec.rb
+++ b/spec/chef/knife/linode_server_create_spec.rb
@@ -1,16 +1,18 @@
-require 'spec_helper'
-require 'linode_server_create'
+require "spec_helper"
+require "linode_server_create"
 
 class MockSocket < BasicSocket
   def initialize; end
+
   def gets; end
+
   def close; end
 end
 
 describe Chef::Knife::LinodeServerCreate do
   subject { Chef::Knife::LinodeServerCreate.new }
 
-  let(:api_key)     { 'FAKE_API_KEY' }
+  let(:api_key)     { "FAKE_API_KEY" }
   let(:mock_socket) { MockSocket.new }
 
   before :each do
@@ -48,15 +50,15 @@ describe Chef::Knife::LinodeServerCreate do
   end
 
   describe "#run" do
-    let(:mock_bootstrap) {
+    let(:mock_bootstrap) do
       double("Chef::Knife::Bootstrap").tap do |mb|
         allow(mb).to receive(:run)
         allow(mb).to receive(:name_args=)
         allow(mb).to receive(:config).and_return({})
       end
-    }
+    end
 
-    let(:mock_server) {
+    let(:mock_server) do
       double("Fog::Compute::Linode::Server").tap do |ms|
         allow(ms).to receive(:ips).and_return([mock_ip("1.2.3.4")])
         allow(ms).to receive(:id).and_return(42)
@@ -64,13 +66,13 @@ describe Chef::Knife::LinodeServerCreate do
         allow(ms).to receive(:status).and_return(1)
         allow(ms).to receive(:public_ip_address)
       end
-    }
+    end
 
-    let(:mock_servers) {
+    let(:mock_servers) do
       double("Fog::Collection").tap do |ms|
         allow(subject.connection).to receive(:servers).and_return(ms)
       end
-    }
+    end
 
     before :each do
       allow(Chef::Knife::Bootstrap).to receive(:new).and_return(mock_bootstrap)
@@ -85,12 +87,12 @@ describe Chef::Knife::LinodeServerCreate do
     end
 
     it "should call #create on the servers collection with the correct params" do
-      skip 'fails - arg variable does not exist'
+      skip "fails - arg variable does not exist"
 
       configure_chef(subject)
 
       expect(mock_servers).to receive(:create) { |server|
-        server.each do |k,v|
+        server.each do |k, v|
           case k
           when :data_center, :flavor, :image, :kernel
             expect(arg[k].id.to_i).to eq(v.id)
@@ -109,7 +111,7 @@ describe Chef::Knife::LinodeServerCreate do
     end
 
     it "should set the bootstrap name_args to the Linode's public IP" do
-      ips = %w( 1.2.3.4 192.168.1.1 ).map { |ip| mock_ip(ip) }
+      ips = %w{ 1.2.3.4 192.168.1.1 }.map { |ip| mock_ip(ip) }
       allow(mock_server).to receive(:ips).and_return(ips)
       expect(mock_bootstrap).to receive(:name_args=).with([ips.first.ip])
 
@@ -176,7 +178,7 @@ def configure_chef(subject)
   }
 
   server_params = {}
-  server.each do |k,v|
+  server.each do |k, v|
     case k
     when :data_center
       server_params[:datacenter] = v.id
@@ -188,7 +190,7 @@ def configure_chef(subject)
   end
 
   # setup the config before we call #run
-  server_params.each do |k,v|
+  server_params.each do |k, v|
     case k
     when :name
       Chef::Config[:knife][:linode_node_name] = v
@@ -207,7 +209,7 @@ def configure_chef(subject)
   end
 
   cli_config = subject.config.dup
-  chef_config.each do |k,v|
+  chef_config.each do |k, v|
     cli_config[k] = v
   end
   allow(subject).to receive(:config).and_return(cli_config)

--- a/spec/chef/knife/linode_server_list_spec.rb
+++ b/spec/chef/knife/linode_server_list_spec.rb
@@ -1,10 +1,10 @@
-require 'spec_helper'
-require 'linode_server_list'
+require "spec_helper"
+require "linode_server_list"
 
 describe Chef::Knife::LinodeServerList do
   subject { Chef::Knife::LinodeServerList.new }
 
-  let(:api_key) { 'FAKE_API_KEY' }
+  let(:api_key) { "FAKE_API_KEY" }
 
   before :each do
     Chef::Knife::LinodeServerList.load_deps

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
-require 'rspec'
-require 'fog'
+require "rspec"
+require "fog"
 
 Fog.mock!
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib', 'chef', 'knife'))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib", "chef", "knife"))


### PR DESCRIPTION
Format the readme
Add gem / travis badges
Add chefstyle
Update instructions for ChefDK (and only DK)
Remove circular link
Opscode -> Chef
Test on modern Ruby
Add dependency on Rake and use a simple rspec + chefstyle rake file
Move dev deps to the Gemfile
Raise if the user doesn't provide the node name since this will fail on an API error later on if not
Add contributing doc link
